### PR TITLE
Add link to STLs uploaded to thingaverse

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If printed at Shapeways or other professional shops, I would not expect such pro
 
 ### Thingiverse
 
-[The 4x5 STL left/right pair](https://www.thingiverse.com/thing:2349390) from the [things/](things/) directory is in the thingiverse here for public printing
+[The 4x5 STL left/right pair](https://www.thingiverse.com/thing:2349390) from the [things/](things/) directory is in the thingiverse for public printing
 
 ### Wiring
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If printed at Shapeways or other professional shops, I would not expect such pro
 
 ### Thingiverse
 
-[The 4x5 STL left/right pair](https://www.thingiverse.com/thing:2349390) from this repos [things/](things/) directory is in the thingiverse here for public printing
+[The 4x5 STL left/right pair](https://www.thingiverse.com/thing:2349390) from the [things/](things/) directory is in the thingiverse here for public printing
 
 ### Wiring
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ On one print, the RJ-9 holder was squished, so I had to cut down my connector to
 
 If printed at Shapeways or other professional shops, I would not expect such problems. 
 
+### Thingaverse
+[The 4x5 STL left/right pair from this repos things directory is in the thingaverse here for public printing](https://www.thingiverse.com/thing:2349390)
+
 ### Wiring
 
 Here are materials I used for wiring.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ On one print, the RJ-9 holder was squished, so I had to cut down my connector to
 If printed at Shapeways or other professional shops, I would not expect such problems. 
 
 ### Thingiverse
-[The 4x5 STL left/right pair] from this repos [things/](things/) directory is in the thingiverse here for public printing(https://www.thingiverse.com/thing:2349390)
+
+[The 4x5 STL left/right pair](https://www.thingiverse.com/thing:2349390) from this repos [things/](things/) directory is in the thingiverse here for public printing
 
 ### Wiring
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ On one print, the RJ-9 holder was squished, so I had to cut down my connector to
 
 If printed at Shapeways or other professional shops, I would not expect such problems. 
 
-### Thingaverse
-[The 4x5 STL left/right pair from this repos things directory is in the thingaverse here for public printing](https://www.thingiverse.com/thing:2349390)
+### Thingiverse
+[The 4x5 STL left/right pair] from this repos [things/](things/) directory is in the thingiverse here for public printing(https://www.thingiverse.com/thing:2349390)
 
 ### Wiring
 


### PR DESCRIPTION
I uploaded your 4x5 STLs to Thingiverse and baught a print.  It is open license with the same artwork license you used here.  If you want a link to it on your readme, merge this pull request.