### PR TITLE
Adding a docker environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM clojure
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+COPY project.clj /usr/src/app
+RUN echo '{:user {:plugins [[lein-exec "0.3.7"]]}}' > ~/.lein/profiles.clj
+RUN lein deps
+COPY . /usr/src/app
+CMD ["lein", "exec", "-ep", "(load-file \"src/dactyl_keyboard/dactyl.clj\")"]

--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ I built a 4x5 version (40% size) for myself. The default has a bit more tenting 
 * Make changes to design, repeat `load-file`, OpenSCAD will watch for changes and rerender.
 * When done, use OpenSCAD to export STL files
 
+**Generate the design (via Docker)*
+* Build the docker container: `docker build -t dactyl .`
+* Run 
+```
+docker run -it --rm \
+-v "$(pwd)/things:/usr/src/app/things" \
+-v "$(pwd)/src:/usr/src/app/src" \
+dactyl lein repl
+```
+* Load the file `(load-file "src/dactyl_keyboard/dactyl.clj")`
+
 **Tips**
 * [Some other ways to evaluate the clojure design file](http://stackoverflow.com/a/28213489)
 * [Example designing with clojure](http://adereth.github.io/blog/2014/04/09/3d-printing-with-clojure/)


### PR DESCRIPTION
Adds a basic Dockerfile with lein exec.

Can be run via repl like the readme, or with

```sh
docker run -it --rm -v "$(pwd)/things:/usr/src/app/things" -v "$(pwd)/src:/usr/src/app/src" dactyl"
```

(but not as quickly).